### PR TITLE
feat: print out pure import statements for purify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngo-loader",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Works with https://github.com/IgorMinar/purify/pull/4.

Import declarations are turned into `webpack_require()` top-level function calls, which can't be removed by Uglify. We can't just prefix them with PURE in this loader because all comment nodes preceding import statements are pushed to the bottom of the file and lose their original positions after the loader runs. We also can't do this directly in the Purify plugin either, because by the time Purify runs, the import structure has already been mangled and there's no way to tell what used to be a pure import  (e.g. `import {x} from 'x/path'` not `import 'rxjs/add/operator/'`).

Instead, we identify import statements with explicit import clauses at this point and print out their paths in a comment.  Purify can then parse the comment after mangling and prefix the correct import statements with PURE to be removed by Uglify.

cc @IgorMinar 